### PR TITLE
feat: adding flutter-driver finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Add `AppiumFlutterFinder` for https://github.com/truongsinh/appium-flutter-driver
 
 ## [0.3.1](0.3.0) - 2021-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 - Add `AppiumFlutterFinder` for https://github.com/truongsinh/appium-flutter-driver
+    - Please read test/unit/flutter_finder_test.dart or their docstring about their usage.
 
 ## [0.3.1](0.3.0) - 2021-03-12
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Below Appium specific commands are implementing.
 - [x] `[HttpMethod.httpPost, 'session/:session_id/appium/log_event']`
 - [x] `[HttpMethod.httpGet, 'session/:session_id/orientation']`
 - [x] `[HttpMethod.httpPost, 'session/:session_id/orientation']`
+- [x] Add finder for https://github.com/truongsinh/appium-flutter-driver
 
 Low priority
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -11,54 +11,36 @@ void main() {
     driver = await createDriver(
         uri: Uri.parse('http://127.0.0.1:4723/wd/hub/'),
         desired: {
-          'platformName': 'android',
-          'udid': 'D0AA002182JC0202126',
-          'deviceName': 'android',
-          'automationName': 'flutter',
-          'app': 'https://github.com/KazuCocoa/my_flutter_app3/blob/main/apps/android-debug/app-debug.apk?raw=true'
-        });
+          'platformName': 'ios',
+          'platformVersion': '14.4',
+          'deviceName': 'iPhone 8',
+          'browserName': 'Safari',
+          'automationName': 'xcuitest',
+          'reduceMotion': true,
+      });
   });
 
   tearDownAll(() async {
     await driver.quit();
   });
 
-  // test('connect to server', () async {
-  //   expect(await driver.title, 'Appium/welcome');
-  // });
-  //
-  // test('connect to existing session', () async {
-  //   var sessionId = driver.id;
-  //
-  //   AppiumWebDriver newDriver = await fromExistingSession(sessionId);
-  //   expect(await newDriver.title, 'Appium/welcome');
-  //   expect(newDriver.id, sessionId);
-  // });
+  test('connect to server', () async {
+    expect(await driver.title, 'Appium/welcome');
+  });
 
-  // test('find by appium element', () async {
-  //   final title = 'Appium/welcome';
-  //   try {
-  //     await driver.findElement(AppiumBy.accessibilityId(title));
-  //     throw 'expected Unsupported locator strategy: accessibility id error';
-  //   } on UnknownException catch (e) {
-  //     expect(
-  //         e.message!.contains('Unsupported locator strategy: accessibility id'),
-  //         true);
-  //   }
-  // });
+  test('connect to existing session', () async {
+    var sessionId = driver.id;
 
-  test('find by appium element with flutter driver', () async {
+    AppiumWebDriver newDriver = await fromExistingSession(sessionId);
+    expect(await newDriver.title, 'Appium/welcome');
+    expect(newDriver.id, sessionId);
+  });
+
+  test('find by appium element', () async {
     final title = 'Appium/welcome';
     try {
-      var finder = base64.encode(utf8.encode(json.encode({
-        "finderType": "ByValueKey",
-        "keyValueString": "increment",
-        "keyValueType": "String"
-      }).toString()));
-      var element = driver.getElement(finder);
-      await element.click();
-
-      sleep(Duration(seconds: 5));
+      await driver.findElement(AppiumBy.accessibilityId(title));
+      throw 'expected Unsupported locator strategy: accessibility id error';
     } on UnknownException catch (e) {
       expect(
           e.message!.contains('Unsupported locator strategy: accessibility id'),

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:appium_driver/async_io.dart';
 import 'package:test/test.dart';
 
@@ -8,12 +11,11 @@ void main() {
     driver = await createDriver(
         uri: Uri.parse('http://127.0.0.1:4723/wd/hub/'),
         desired: {
-          'platformName': 'ios',
-          'platformVersion': '14.4',
-          'deviceName': 'iPhone 8',
-          'browserName': 'Safari',
-          'automationName': 'xcuitest',
-          'reduceMotion': true,
+          'platformName': 'android',
+          'udid': 'D0AA002182JC0202126',
+          'deviceName': 'android',
+          'automationName': 'flutter',
+          'app': 'https://github.com/KazuCocoa/my_flutter_app3/blob/main/apps/android-debug/app-debug.apk?raw=true'
         });
   });
 
@@ -21,23 +23,42 @@ void main() {
     await driver.quit();
   });
 
-  test('connect to server', () async {
-    expect(await driver.title, 'Appium/welcome');
-  });
+  // test('connect to server', () async {
+  //   expect(await driver.title, 'Appium/welcome');
+  // });
+  //
+  // test('connect to existing session', () async {
+  //   var sessionId = driver.id;
+  //
+  //   AppiumWebDriver newDriver = await fromExistingSession(sessionId);
+  //   expect(await newDriver.title, 'Appium/welcome');
+  //   expect(newDriver.id, sessionId);
+  // });
 
-  test('connect to existing session', () async {
-    var sessionId = driver.id;
+  // test('find by appium element', () async {
+  //   final title = 'Appium/welcome';
+  //   try {
+  //     await driver.findElement(AppiumBy.accessibilityId(title));
+  //     throw 'expected Unsupported locator strategy: accessibility id error';
+  //   } on UnknownException catch (e) {
+  //     expect(
+  //         e.message!.contains('Unsupported locator strategy: accessibility id'),
+  //         true);
+  //   }
+  // });
 
-    AppiumWebDriver newDriver = await fromExistingSession(sessionId);
-    expect(await newDriver.title, 'Appium/welcome');
-    expect(newDriver.id, sessionId);
-  });
-
-  test('find by appium element', () async {
+  test('find by appium element with flutter driver', () async {
     final title = 'Appium/welcome';
     try {
-      await driver.findElement(AppiumBy.accessibilityId(title));
-      throw 'expected Unsupported locator strategy: accessibility id error';
+      var finder = base64.encode(utf8.encode(json.encode({
+        "finderType": "ByValueKey",
+        "keyValueString": "increment",
+        "keyValueType": "String"
+      }).toString()));
+      var element = driver.getElement(finder);
+      await element.click();
+
+      sleep(Duration(seconds: 5));
     } on UnknownException catch (e) {
       expect(
           e.message!.contains('Unsupported locator strategy: accessibility id'),

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,6 +1,3 @@
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:appium_driver/async_io.dart';
 import 'package:test/test.dart';
 
@@ -17,7 +14,7 @@ void main() {
           'browserName': 'Safari',
           'automationName': 'xcuitest',
           'reduceMotion': true,
-      });
+        });
   });
 
   tearDownAll(() async {

--- a/lib/src/async/session.dart
+++ b/lib/src/async/session.dart
@@ -12,8 +12,9 @@ class Session {
 
   /// Get sessions
   ///
-  /// @example
-  ///   driver.session.getCapabilities()
+  /// ```dart
+  /// driver.session.getCapabilities()
+  /// ```
   Future<Map<String, dynamic>> getCapabilities() => _client.send(
       _handler.session.buildGetCapabilitiesRequest(),
       _handler.session.parseGetCapabilitiesResponse);

--- a/lib/src/async/sessions.dart
+++ b/lib/src/async/sessions.dart
@@ -16,14 +16,15 @@ class Sessions {
 
   /// Get sessions
   ///
-  /// @example
-  ///   driver.sessions.get()
-  ///   #=> [
-  ///     {"id":"3ec13c12-9199-4d03-ba8c-51925d184316",
-  ///      "capabilities":{"platformName":"iOS","browserName":"Safari",
-  ///        "platformVersion":"12.2","deviceName":"iPhone 8",
-  ///        "automationName":"xcuitest","wdaLocalPort":8101,
-  ///        "useJSONSource":true,"reduceMotion":true}}]
+  /// ```dart
+  /// driver.sessions.get()
+  /// //=> [
+  /// // {"id":"3ec13c12-9199-4d03-ba8c-51925d184316",
+  /// //   "capabilities":{"platformName":"iOS","browserName":"Safari",
+  /// //   "platformVersion":"12.2","deviceName":"iPhone 8",
+  /// //   "automationName":"xcuitest","wdaLocalPort":8101,
+  /// //   "useJSONSource":true,"reduceMotion":true}}]
+  /// ```
   Future<List<dynamic>> get() => _client!.send(
       _handler!.sessions.buildGetRequest(),
       _handler!.sessions.parseGetResponse);

--- a/lib/src/async/status.dart
+++ b/lib/src/async/status.dart
@@ -16,11 +16,12 @@ class Status {
 
   /// Get sessions
   ///
-  /// @example
-  ///   driver.sessions.get()
-  ///   #=> {"build":{"version":"1.14.0-beta.2",
-  ///   "git-sha":"8a690f5abde5cf1c74f1cd185f15f51b3f7c3920",
-  ///   "built":"2019-06-25 16:21:45 -0700"}}
+  /// ```dart
+  /// driver.sessions.get()
+  /// //=> {"build":{"version":"1.14.0-beta.2",
+  /// // "git-sha":"8a690f5abde5cf1c74f1cd185f15f51b3f7c3920",
+  /// // "built":"2019-06-25 16:21:45 -0700"}}
+  /// ```
   Future<Map<String, dynamic>> get() => _client!.send(
       _handler!.status.buildGetRequest(), _handler!.status.parseGetResponse);
 

--- a/lib/src/common/flutter_finder.dart
+++ b/lib/src/common/flutter_finder.dart
@@ -1,6 +1,15 @@
 import 'dart:convert';
 
 class AppiumFlutterFinder {
+  /// Returns base64 encoded string as a finder for appium-flutter-driver
+  /// with the given [label].
+  /// https://github.com/truongsinh/appium-flutter-driver#finders
+  ///
+  /// ```dart
+  /// var finder = AppiumFlutterFinder.bySemanticsLabel('simple')
+  /// var element = driver.getElement(finder);
+  /// await element.click();  // Do actions against the element
+  /// ```
   static String bySemanticsLabel(String label) {
     return base64.encode(utf8.encode(json.encode({
       'finderType': 'BySemanticsLabel',
@@ -9,6 +18,16 @@ class AppiumFlutterFinder {
     }).toString()));
   }
 
+  /// Returns base64 encoded string as a finder for appium-flutter-driver
+  /// with the given [label]. It should be Regex as string.
+  /// https://github.com/truongsinh/appium-flutter-driver#finders
+  /// https://api.flutter.dev/flutter/dart-core/RegExp-class.html
+  ///
+  /// ```dart
+  /// var finder = AppiumFlutterFinder.bySemanticsLabelWithRegExp('(\w+)')
+  /// var element = driver.getElement(finder);
+  /// await element.click();  // Do actions against the element
+  /// ```
   static String bySemanticsLabelWithRegExp(String label) {
     print(label.toString());
 
@@ -19,16 +38,43 @@ class AppiumFlutterFinder {
     }).toString()));
   }
 
+  /// Returns base64 encoded string as a finder for appium-flutter-driver
+  /// with the given [text].
+  /// https://github.com/truongsinh/appium-flutter-driver#finders
+  ///
+  /// ```dart
+  /// var finder = AppiumFlutterFinder.byTooltip('sample')
+  /// var element = driver.getElement(finder);
+  /// await element.click();  // Do actions against the element
+  /// ```
   static String byTooltip(String text) {
     return base64.encode(utf8.encode(json
         .encode({'finderType': 'ByTooltipMessage', 'text': text}).toString()));
   }
 
+  /// Returns base64 encoded string as a finder for appium-flutter-driver
+  /// with the given [type].
+  /// https://github.com/truongsinh/appium-flutter-driver#finders
+  ///
+  /// ```dart
+  /// var finder = AppiumFlutterFinder.byTooltip('myText')
+  /// var element = driver.getElement(finder);
+  /// await element.click();  // Do actions against the element
+  /// ```
   static String byType(String type) {
     return base64.encode(utf8.encode(
         json.encode({'finderType': 'ByType', 'type': type}).toString()));
   }
 
+  /// Returns base64 encoded string as a finder for appium-flutter-driver
+  /// with the given [key] as int.
+  /// https://github.com/truongsinh/appium-flutter-driver#finders
+  ///
+  /// ```dart
+  /// var finder = AppiumFlutterFinder.key(42)
+  /// var element = driver.getElement(finder);
+  /// await element.click();  // Do actions against the element
+  /// ```
   static String byKeyValueInt(int key) {
     return base64.encode(utf8.encode(json.encode({
       'finderType': 'ByValueKey',
@@ -37,6 +83,15 @@ class AppiumFlutterFinder {
     }).toString()));
   }
 
+  /// Returns base64 encoded string as a finder for appium-flutter-driver
+  /// with the given [key] as string.
+  /// https://github.com/truongsinh/appium-flutter-driver#finders
+  ///
+  /// ```dart
+  /// var finder = AppiumFlutterFinder.key('42')
+  /// var element = driver.getElement(finder);
+  /// await element.click();  // Do actions against the element
+  /// ```
   static String byKeyValueString(String key) {
     return base64.encode(utf8.encode(json.encode({
       'finderType': 'ByValueKey',
@@ -45,6 +100,14 @@ class AppiumFlutterFinder {
     }).toString()));
   }
 
+  /// Returns base64 encoded string as a finder for appium-flutter-driver.
+  /// https://github.com/truongsinh/appium-flutter-driver#finders
+  ///
+  /// ```dart
+  /// var finder = AppiumFlutterFinder.pageBack()
+  /// var element = driver.getElement(finder);
+  /// await element.click();  // Do actions against the element
+  /// ```
   static String pageBack() {
     return base64.encode(
         utf8.encode(json.encode({'finderType': 'PageBack'}).toString()));
@@ -55,16 +118,62 @@ class AppiumFlutterFinder {
         json.encode({'finderType': 'ByText', 'text': text}).toString()));
   }
 
-  static String byAncestor(String serializedFinder, String matching,
-      {bool matchingRoot: false}) {
+  /// Returns base64 encoded string as a finder for appium-flutter-driver
+  /// with the given [of], [matching] and [matchingRoot].
+  /// https://github.com/truongsinh/appium-flutter-driver#finders
+  ///
+  /// Please read https://api.flutter.dev/flutter/flutter_driver/CommonFinders/ancestor.html
+  /// for more details about each arguments.
+  ///
+  /// ```dart
+  /// var finder = AppiumFlutterFinder.byAncestor(
+  ///                  of: AppiumFlutterFinder.byAncestor(
+  ///                      of: AppiumFlutterFinder.pageBack(),
+  ///                      matching: AppiumFlutterFinder.pageBack(),
+  ///                      matchingRoot: false),
+  ///                  matching: AppiumFlutterFinder.byAncestor(
+  ///                      of: AppiumFlutterFinder.pageBack(),
+  ///                      matching: AppiumFlutterFinder.pageBack(),
+  ///                      matchingRoot: false),
+  ///                  matchingRoot: false)
+  /// var element = driver.getElement(finder);
+  /// await element.click();  // Do actions against the element
+  /// ```
+  static String byAncestor(
+      {required String of,
+      required String matching,
+      bool matchingRoot = false}) {
     return AppiumFlutterFinder._byAncestorOrDescendant(
-        'Ancestor', serializedFinder, matching, matchingRoot);
+        'Ancestor', of, matching, matchingRoot);
   }
 
-  static String byDescendant(String serializedFinder, String matching,
-      {bool matchingRoot: false}) {
+  /// Returns base64 encoded string as a finder for appium-flutter-driver
+  /// with the given [of], [matching] and [matchingRoot].
+  /// https://github.com/truongsinh/appium-flutter-driver#finders
+  ///
+  /// Please read https://api.flutter.dev/flutter/flutter_driver/CommonFinders/descendant.html
+  /// for more details about each arguments.
+  ///
+  /// ```dart
+  /// var finder = AppiumFlutterFinder.byDescendant(
+  ///                  of: AppiumFlutterFinder.byDescendant(
+  ///                      of: AppiumFlutterFinder.pageBack(),
+  ///                      matching: AppiumFlutterFinder.pageBack(),
+  ///                      matchingRoot: false),
+  ///                  matching: AppiumFlutterFinder.byDescendant(
+  ///                      of: AppiumFlutterFinder.pageBack(),
+  ///                      matching: AppiumFlutterFinder.pageBack(),
+  ///                      matchingRoot: false),
+  ///                  matchingRoot: false)
+  /// var element = driver.getElement(finder);
+  /// await element.click();  // Do actions against the element
+  /// ```
+  static String byDescendant(
+      {required String of,
+      required String matching,
+      bool matchingRoot = false}) {
     return AppiumFlutterFinder._byAncestorOrDescendant(
-        'Descendant', serializedFinder, matching, matchingRoot);
+        'Descendant', of, matching, matchingRoot);
   }
 
   static String _byAncestorOrDescendant(String type, String serializedFinder,

--- a/lib/src/common/flutter_finder.dart
+++ b/lib/src/common/flutter_finder.dart
@@ -30,24 +30,22 @@ class AppiumFlutterFinder {
   }
 
   static String byKeyValueInt(int key) {
-    return base64.encode(utf8.encode(
-        json.encode({
-          'finderType': 'ByValueKey',
-          'keyValueString': key,
-          'keyValueType': 'int'
-        }).toString()));
+    return base64.encode(utf8.encode(json.encode({
+      'finderType': 'ByValueKey',
+      'keyValueString': key,
+      'keyValueType': 'int'
+    }).toString()));
   }
 
   static String byKeyValueString(String key) {
-    return base64.encode(utf8.encode(
-        json.encode({
-          'finderType': 'ByValueKey',
-          'keyValueString': key,
-          'keyValueType': 'String'
-        }).toString()));
+    return base64.encode(utf8.encode(json.encode({
+      'finderType': 'ByValueKey',
+      'keyValueString': key,
+      'keyValueType': 'String'
+    }).toString()));
   }
 
-  static String pageBack(String type) {
+  static String pageBack() {
     return base64.encode(
         utf8.encode(json.encode({'finderType': 'PageBack'}).toString()));
   }
@@ -55,6 +53,39 @@ class AppiumFlutterFinder {
   static String byText(String text) {
     return base64.encode(utf8.encode(
         json.encode({'finderType': 'ByText', 'text': text}).toString()));
+  }
+
+  static String byAncestor(String serializedFinder, String matching,
+      {bool matchingRoot: false}) {
+    return AppiumFlutterFinder._byAncestorOrDescendant(
+        'Ancestor', serializedFinder, matching, matchingRoot);
+  }
+
+  static String byDescendant(String serializedFinder, String matching,
+      {bool matchingRoot: false}) {
+    return AppiumFlutterFinder._byAncestorOrDescendant(
+        'Descendant', serializedFinder, matching, matchingRoot);
+  }
+
+  static String _byAncestorOrDescendant(String type, String serializedFinder,
+      String matching, bool matchingRoot) {
+    var param = {'finderType': type, 'matchRoot': matchingRoot};
+    var finder = json.decode(utf8.decode(base64.decode(serializedFinder)));
+
+    if (finder != null) {
+      finder.forEach((key, value) {
+        param['of_$key'] = value;
+      });
+    }
+
+    var matchingValue = json.decode(utf8.decode(base64.decode(matching)));
+    if (matchingValue != null) {
+      matchingValue.forEach((key, value) {
+        param['matching_$key'] = value;
+      });
+    }
+
+    return base64.encode(utf8.encode(json.encode(param).toString()));
   }
 
   // static byAncestor(String serializedFinder, )

--- a/lib/src/common/flutter_finder.dart
+++ b/lib/src/common/flutter_finder.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+
+class AppiumFlutterFinder {
+  static String bySemanticsLabel(String label) {
+    return base64.encode(utf8.encode(json.encode({
+      'finderType': 'BySemanticsLabel',
+      'isRegExp': false,
+      'label': label
+    }).toString()));
+  }
+
+  static String bySemanticsLabelWithRegExp(String label) {
+    print(label.toString());
+
+    return base64.encode(utf8.encode(json.encode({
+      'finderType': 'BySemanticsLabel',
+      'isRegExp': true,
+      'label': label
+    }).toString()));
+  }
+
+  static String byTooltip(String text) {
+    return base64.encode(utf8.encode(json
+        .encode({'finderType': 'ByTooltipMessage', 'text': text}).toString()));
+  }
+
+  static String byType(String type) {
+    return base64.encode(utf8.encode(
+        json.encode({'finderType': 'ByType', 'type': type}).toString()));
+  }
+
+  static String byKeyValueInt(int key) {
+    return base64.encode(utf8.encode(
+        json.encode({
+          'finderType': 'ByValueKey',
+          'keyValueString': key,
+          'keyValueType': 'int'
+        }).toString()));
+  }
+
+  static String byKeyValueString(String key) {
+    return base64.encode(utf8.encode(
+        json.encode({
+          'finderType': 'ByValueKey',
+          'keyValueString': key,
+          'keyValueType': 'String'
+        }).toString()));
+  }
+
+  static String pageBack(String type) {
+    return base64.encode(
+        utf8.encode(json.encode({'finderType': 'PageBack'}).toString()));
+  }
+
+  static String byText(String text) {
+    return base64.encode(utf8.encode(
+        json.encode({'finderType': 'ByText', 'text': text}).toString()));
+  }
+
+  // static byAncestor(String serializedFinder, )
+  //
+  //
+  // def by_ancestor(serialized_finder:, matching:, match_root: false)
+  // by_ancestor_or_descendant(
+  // type: 'Ancestor',
+  // serialized_finder: serialized_finder,
+  // matching: matching,
+  // match_root: match_root
+  // )
+  // end
+  //
+  // def by_descendant(serialized_finder:, matching:, match_root: false)
+  // by_ancestor_or_descendant(
+  // type: 'Descendant',
+  // serialized_finder: serialized_finder,
+  // matching: matching,
+  // match_root: match_root
+  // )
+  // end
+}

--- a/lib/src/handler/w3c/session.dart
+++ b/lib/src/handler/w3c/session.dart
@@ -13,7 +13,7 @@ class W3cSessionHandler extends SessionHandler {
   WebDriverRequest buildCreateRequest({Map<String, dynamic>? desired}) {
     desired ??= Capabilities.empty;
     return WebDriverRequest.postRequest('session', {
-      'capabilities': {'alwaysMatch': desired}
+      'capabilities': {'alwaysMatch': desired, 'firstMatch': [{}]}
     });
   }
 

--- a/lib/src/handler/w3c/session.dart
+++ b/lib/src/handler/w3c/session.dart
@@ -13,7 +13,10 @@ class W3cSessionHandler extends SessionHandler {
   WebDriverRequest buildCreateRequest({Map<String, dynamic>? desired}) {
     desired ??= Capabilities.empty;
     return WebDriverRequest.postRequest('session', {
-      'capabilities': {'alwaysMatch': desired, 'firstMatch': [{}]}
+      'capabilities': {
+        'alwaysMatch': desired,
+        'firstMatch': [{}]
+      }
     });
   }
 

--- a/test/unit/flutter_finder_test.dart
+++ b/test/unit/flutter_finder_test.dart
@@ -8,10 +8,13 @@ void main() {
     test('byAncestor', () {
       expect(
           AppiumFlutterFinder.byAncestor(
-              AppiumFlutterFinder.byAncestor(AppiumFlutterFinder.pageBack(),
-                  AppiumFlutterFinder.pageBack(), matchingRoot: false),
-              AppiumFlutterFinder.byAncestor(AppiumFlutterFinder.pageBack(),
-                  AppiumFlutterFinder.pageBack(),
+              of: AppiumFlutterFinder.byAncestor(
+                  of: AppiumFlutterFinder.pageBack(),
+                  matching: AppiumFlutterFinder.pageBack(),
+                  matchingRoot: false),
+              matching: AppiumFlutterFinder.byAncestor(
+                  of: AppiumFlutterFinder.pageBack(),
+                  matching: AppiumFlutterFinder.pageBack(),
                   matchingRoot: false),
               matchingRoot: false),
           'eyJmaW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJtYXRjaFJvb3QiOmZhbHNlLCJvZl9maW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJvZl9tYXRjaFJvb3QiOmZhbHNlLCJvZl9vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJvZl9tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19maW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJtYXRjaGluZ19tYXRjaFJvb3QiOmZhbHNlLCJtYXRjaGluZ19vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2sifQ==');
@@ -20,10 +23,13 @@ void main() {
     test('byDescendant', () {
       expect(
           AppiumFlutterFinder.byDescendant(
-              AppiumFlutterFinder.byDescendant(AppiumFlutterFinder.pageBack(),
-                  AppiumFlutterFinder.pageBack(), matchingRoot: false),
-              AppiumFlutterFinder.byDescendant(AppiumFlutterFinder.pageBack(),
-                  AppiumFlutterFinder.pageBack(),
+              of: AppiumFlutterFinder.byDescendant(
+                  of: AppiumFlutterFinder.pageBack(),
+                  matching: AppiumFlutterFinder.pageBack(),
+                  matchingRoot: false),
+              matching: AppiumFlutterFinder.byDescendant(
+                  of: AppiumFlutterFinder.pageBack(),
+                  matching: AppiumFlutterFinder.pageBack(),
                   matchingRoot: false),
               matchingRoot: false),
           'eyJmaW5kZXJUeXBlIjoiRGVzY2VuZGFudCIsIm1hdGNoUm9vdCI6ZmFsc2UsIm9mX2ZpbmRlclR5cGUiOiJEZXNjZW5kYW50Iiwib2ZfbWF0Y2hSb290IjpmYWxzZSwib2Zfb2ZfZmluZGVyVHlwZSI6IlBhZ2VCYWNrIiwib2ZfbWF0Y2hpbmdfZmluZGVyVHlwZSI6IlBhZ2VCYWNrIiwibWF0Y2hpbmdfZmluZGVyVHlwZSI6IkRlc2NlbmRhbnQiLCJtYXRjaGluZ19tYXRjaFJvb3QiOmZhbHNlLCJtYXRjaGluZ19vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2sifQ==');

--- a/test/unit/flutter_finder_test.dart
+++ b/test/unit/flutter_finder_test.dart
@@ -70,25 +70,3 @@ void main() {
         'eyJmaW5kZXJUeXBlIjoiQnlUZXh0IiwidGV4dCI6IlRoaXMgaXMgMm5kIHJvdXRlIn0=');
   });
 }
-
-//   // static byAncestor(String serializedFinder, )
-//   //
-//   //
-//   // def by_ancestor(serialized_finder:, matching:, match_root: false)
-//   // by_ancestor_or_descendant(
-//   // type: 'Ancestor',
-//   // serialized_finder: serialized_finder,
-//   // matching: matching,
-//   // match_root: match_root
-//   // )
-//   // end
-//   //
-//   // def by_descendant(serialized_finder:, matching:, match_root: false)
-//   // by_ancestor_or_descendant(
-//   // type: 'Descendant',
-//   // serialized_finder: serialized_finder,
-//   // matching: matching,
-//   // match_root: match_root
-//   // )
-//   // end
-// }

--- a/test/unit/flutter_finder_test.dart
+++ b/test/unit/flutter_finder_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+
+import 'package:appium_driver/src/common/flutter_finder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('flutter finders', () {
+    test('bySemanticsLabel', () {
+      expect(AppiumFlutterFinder.bySemanticsLabel('simple'),
+          'eyJmaW5kZXJUeXBlIjoiQnlTZW1hbnRpY3NMYWJlbCIsImlzUmVnRXhwIjpmYWxzZSwibGFiZWwiOiJzaW1wbGUifQ==');
+    });
+
+    test('bySemanticsLabelWithRegExp', () {
+      expect(AppiumFlutterFinder.bySemanticsLabelWithRegExp(r'complicated'),
+          'eyJmaW5kZXJUeXBlIjoiQnlTZW1hbnRpY3NMYWJlbCIsImlzUmVnRXhwIjp0cnVlLCJsYWJlbCI6ImNvbXBsaWNhdGVkIn0=');
+    });
+  });
+
+  test('byTooltip', () {
+    expect(AppiumFlutterFinder.byTooltip('myText'),
+        'eyJmaW5kZXJUeXBlIjoiQnlUb29sdGlwTWVzc2FnZSIsInRleHQiOiJteVRleHQifQ==');
+  });
+
+  test('byType', () {
+    expect(AppiumFlutterFinder.byType('myText'),
+        'eyJmaW5kZXJUeXBlIjoiQnlUeXBlIiwidHlwZSI6Im15VGV4dCJ9');
+  });
+
+  test('byKeyValueInt', () {
+    expect(AppiumFlutterFinder.byKeyValueInt(42),
+        'eyJmaW5kZXJUeXBlIjoiQnlWYWx1ZUtleSIsImtleVZhbHVlU3RyaW5nIjo0Miwia2V5VmFsdWVUeXBlIjoiaW50In0=');
+  });
+
+  test('byKeyValueString', () {
+    expect(AppiumFlutterFinder.byKeyValueString('42'),
+        'eyJmaW5kZXJUeXBlIjoiQnlWYWx1ZUtleSIsImtleVZhbHVlU3RyaW5nIjoiNDIiLCJrZXlWYWx1ZVR5cGUiOiJTdHJpbmcifQ==');
+  });
+
+  test('pageBack', () {
+    expect(AppiumFlutterFinder.pageBack('42'),
+        'eyJmaW5kZXJUeXBlIjoiUGFnZUJhY2sifQ==');
+  });
+
+  test('byText', () {
+    expect(AppiumFlutterFinder.byText('This is 2nd route'),
+        'eyJmaW5kZXJUeXBlIjoiQnlUZXh0IiwidGV4dCI6IlRoaXMgaXMgMm5kIHJvdXRlIn0=');
+  });
+}
+
+//   // static byAncestor(String serializedFinder, )
+//   //
+//   //
+//   // def by_ancestor(serialized_finder:, matching:, match_root: false)
+//   // by_ancestor_or_descendant(
+//   // type: 'Ancestor',
+//   // serialized_finder: serialized_finder,
+//   // matching: matching,
+//   // match_root: match_root
+//   // )
+//   // end
+//   //
+//   // def by_descendant(serialized_finder:, matching:, match_root: false)
+//   // by_ancestor_or_descendant(
+//   // type: 'Descendant',
+//   // serialized_finder: serialized_finder,
+//   // matching: matching,
+//   // match_root: match_root
+//   // )
+//   // end
+// }

--- a/test/unit/flutter_finder_test.dart
+++ b/test/unit/flutter_finder_test.dart
@@ -5,6 +5,30 @@ import 'package:test/test.dart';
 
 void main() {
   group('flutter finders', () {
+    test('byAncestor', () {
+      expect(
+          AppiumFlutterFinder.byAncestor(
+              AppiumFlutterFinder.byAncestor(AppiumFlutterFinder.pageBack(),
+                  AppiumFlutterFinder.pageBack(), matchingRoot: false),
+              AppiumFlutterFinder.byAncestor(AppiumFlutterFinder.pageBack(),
+                  AppiumFlutterFinder.pageBack(),
+                  matchingRoot: false),
+              matchingRoot: false),
+          'eyJmaW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJtYXRjaFJvb3QiOmZhbHNlLCJvZl9maW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJvZl9tYXRjaFJvb3QiOmZhbHNlLCJvZl9vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJvZl9tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19maW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJtYXRjaGluZ19tYXRjaFJvb3QiOmZhbHNlLCJtYXRjaGluZ19vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2sifQ==');
+    });
+
+    test('byDescendant', () {
+      expect(
+          AppiumFlutterFinder.byDescendant(
+              AppiumFlutterFinder.byDescendant(AppiumFlutterFinder.pageBack(),
+                  AppiumFlutterFinder.pageBack(), matchingRoot: false),
+              AppiumFlutterFinder.byDescendant(AppiumFlutterFinder.pageBack(),
+                  AppiumFlutterFinder.pageBack(),
+                  matchingRoot: false),
+              matchingRoot: false),
+          'eyJmaW5kZXJUeXBlIjoiRGVzY2VuZGFudCIsIm1hdGNoUm9vdCI6ZmFsc2UsIm9mX2ZpbmRlclR5cGUiOiJEZXNjZW5kYW50Iiwib2ZfbWF0Y2hSb290IjpmYWxzZSwib2Zfb2ZfZmluZGVyVHlwZSI6IlBhZ2VCYWNrIiwib2ZfbWF0Y2hpbmdfZmluZGVyVHlwZSI6IlBhZ2VCYWNrIiwibWF0Y2hpbmdfZmluZGVyVHlwZSI6IkRlc2NlbmRhbnQiLCJtYXRjaGluZ19tYXRjaFJvb3QiOmZhbHNlLCJtYXRjaGluZ19vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2sifQ==');
+    });
+
     test('bySemanticsLabel', () {
       expect(AppiumFlutterFinder.bySemanticsLabel('simple'),
           'eyJmaW5kZXJUeXBlIjoiQnlTZW1hbnRpY3NMYWJlbCIsImlzUmVnRXhwIjpmYWxzZSwibGFiZWwiOiJzaW1wbGUifQ==');
@@ -37,8 +61,8 @@ void main() {
   });
 
   test('pageBack', () {
-    expect(AppiumFlutterFinder.pageBack('42'),
-        'eyJmaW5kZXJUeXBlIjoiUGFnZUJhY2sifQ==');
+    expect(
+        AppiumFlutterFinder.pageBack(), 'eyJmaW5kZXJUeXBlIjoiUGFnZUJhY2sifQ==');
   });
 
   test('byText', () {


### PR DESCRIPTION
Adding a template finder like https://github.com/truongsinh/appium-flutter-driver/blob/master/finder/ruby/lib/appium_flutter_finder.rb ...

appium-flutter-driver must accept W3C capabilities to work with this.


Closes https://github.com/KazuCocoa/appium_dart/issues/24 . No need to add a separate library