### PR TITLE
handling exception upon constructing SessionInfo() instance

### DIFF
--- a/lib/src/handler/w3c/session.dart
+++ b/lib/src/handler/w3c/session.dart
@@ -23,8 +23,12 @@ class W3cSessionHandler extends SessionHandler {
   @override
   SessionInfo parseCreateResponse(WebDriverResponse response) {
     final session = parseW3cResponse(response);
-    return SessionInfo(
-        session['sessionId'], WebDriverSpec.W3c, session['capabilities']);
+    try {
+      return SessionInfo(
+          session['sessionId'], WebDriverSpec.W3c, session['capabilities']);
+    } catch (e){
+      throw Exception(session);
+    }
   }
 
   /// Requesting existing session info is not supported in W3c.


### PR DESCRIPTION
#45 

This provide an informative error when exception occur upon constructing "SessionInfo()" instance.

Sample of the exception after change:

`Exception: {error: [BROWSERSTACK_MISSING_CAPS] The ["deviceName"] capabilities are missing in your test script. Please refer to our capability builder - https://www.browserstack.com/app-automate/capabilities?tag=w3c, message: [BROWSERSTACK_MISSING_CAPS] The ["deviceName"] capabilities are missing in your test script. Please refer to our capability builder - https://www.browserstack.com/app-automate/capabilities?tag=w3c}`