### PR TITLE
ci: Add Dart 3.7 and 3.8 to GitHub Actions matrix

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [2.19, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, beta]
+        sdk: [2.19, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, beta]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
closes https://github.com/KazuCocoa/appium_dart/issues/64